### PR TITLE
Format images to specified format

### DIFF
--- a/config/imageresizer.php
+++ b/config/imageresizer.php
@@ -4,5 +4,13 @@ return [
         '100x100', // Cart
         '450',     // Product
         '200',     // Category
-    ]
+    ],
+
+    /**
+     * The format the images should be outputted to.
+     *
+     * Set `null` to keep the default formatting of the uploaded images
+     * Supported Formats: `jpg`, `pjpg`, `png`, `gif`, `webp`
+     **/
+    'output_format' => 'webp',
 ];


### PR DESCRIPTION
This PR allows for formatting images to webp or other supported formats specified in `config/imageresizer.php`.

The link on the frontend isn't edited to the new format and still show the given format from magento.
example:
`<img src="/storage/resizes/200/catalog/product/w/h/wh01-green_main_1.jpg" alt="Mona Pullover Hoodlie" loading="lazy" class="object-contain rounded-t h-48 w-full mb-3">`

But when visiting link `/storage/resizes/200/catalog/product/w/h/wh01-green_main_1.jpg` and going to network tab in has a webp format.
<img width="452" alt="Screen Shot 2021-06-01 at 3 18 40 PM" src="https://user-images.githubusercontent.com/36452184/120330100-c77f2100-c2ec-11eb-9069-bb321a084452.png">
