### PR TITLE
Clean up watermark after it has been used

### DIFF
--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -85,6 +85,8 @@ class ImageController extends Controller
             ->watermarkPosition(config('imageresizer.watermarks.positions.'.Config::getCachedByPath('design/watermark/'.$watermark.'_position', 'center')))
             ->watermarkHeight($height, Manipulations::UNIT_PIXELS)
             ->watermarkWidth($width, Manipulations::UNIT_PIXELS);
+        
+        unlink($tempWatermark);
 
         return $image;
     }

--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -85,7 +85,7 @@ class ImageController extends Controller
             ->watermarkPosition(config('imageresizer.watermarks.positions.'.Config::getCachedByPath('design/watermark/'.$watermark.'_position', 'center')))
             ->watermarkHeight($height, Manipulations::UNIT_PIXELS)
             ->watermarkWidth($width, Manipulations::UNIT_PIXELS);
-        
+
         unlink($tempWatermark);
 
         return $image;


### PR DESCRIPTION
Contrary to expectations the /tmp folder does not actually get emptied automatically, it is expected that scripts clean up after themselves