### PR TITLE
Added option to specify separate filename

### DIFF
--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -14,7 +14,7 @@ class ImageController extends Controller
 {
     protected array $tmpPaths = [];
 
-    public function __invoke(Request $request, string $size, string $file, string $webp = '')
+    public function __invoke(Request $request, string $size, string $file, string $webp = '', string|bool $fileName = false)
     {
         abort_unless(in_array($size, config('imageresizer.sizes')), 400, 'The requested size is not whitelisted.');
 
@@ -30,7 +30,7 @@ class ImageController extends Controller
             ? $placeholder
             : 'local';
 
-        $resizedPath = config('rapidez.store').'/resizes/'.$placeholder.'/'.$size.'/'.$file.$webp;
+        $resizedPath = config('rapidez.store').'/resizes/'.$placeholder.'/'.$size.'/'.($fileName ?? $file).$webp;
 
         if (!$this->storage()->exists($resizedPath)) {
             $content = isset($placeholderUrl)


### PR DESCRIPTION
This adds the option to specify a separate filename. This can be useful, for example, if the filename becomes too long. This is sometimes the case when generating the resized images for external images.