### PR TITLE
Name the image resize path

### DIFF
--- a/src/ImageResizerServiceProvider.php
+++ b/src/ImageResizerServiceProvider.php
@@ -17,7 +17,8 @@ class ImageResizerServiceProvider extends ServiceProvider
     public function boot()
     {
         Route::get('storage/resizes/{size}/{file}{webp?}', ImageController::class)
-            ->where(['file' => '.*\.((?!webp)[^\.])+', 'webp' => '\.webp']);
+            ->where(['file' => '.*\.((?!webp)[^\.])+', 'webp' => '\.webp'])
+            ->name('resized-image');
 
         $this->mergeConfigFrom(__DIR__.'/../config/imageresizer.php', 'imageresizer');
 


### PR DESCRIPTION
This allows us to generate the resize url like so
```php
route('resized-image', ['size' => '50x60', 'file' => 'magento/catalog/product/...', 'webp' => '.webp'])
```