### PR TITLE
Fix internal server error when navigating to /storage/resizes/a/a/a.a

### DIFF
--- a/src/ImageResizerServiceProvider.php
+++ b/src/ImageResizerServiceProvider.php
@@ -30,7 +30,7 @@ class ImageResizerServiceProvider extends ServiceProvider
             ->name('resized-image');
 
         // Backwards compatibility step.
-        Route::get('storage/resizes/{size}/{placeholder}/{file}{webp?}', function (string $size, string $placeholder, string $file, string $webp) {
+        Route::get('storage/resizes/{size}/{placeholder}/{file}{webp?}', function (string $size, string $placeholder, string $file, string $webp = '') {
             return redirect(route('resized-image', ['store' => config('rapidez.store'), ...compact('size', 'placeholder', 'file', 'webp')]), 301);
         })->where(self::PATTERNS);
 


### PR DESCRIPTION
When a url of this format gets visited, it tries to pass only 3 arguments to the closure which requires 4. This change makes the missing 4th argument an optional argument.