### PR TITLE
Make gd the default driver

### DIFF
--- a/config/rapidez/imageresizer.php
+++ b/config/rapidez/imageresizer.php
@@ -9,7 +9,7 @@ return [
     // Which driver should be used? Two options:
     // - gd
     // - imagick
-    'driver' => env('RAPIDEZ_IMAGE_DRIVER', 'imagick'),
+    'driver' => env('RAPIDEZ_IMAGE_DRIVER', 'gd'),
 
     'sizes' => [
         '80x80',   // Thumbs

--- a/config/rapidez/imageresizer.php
+++ b/config/rapidez/imageresizer.php
@@ -9,7 +9,7 @@ return [
     // Which driver should be used? Two options:
     // - gd
     // - imagick
-    'driver' => env('RAPIDEZ_IMAGE_DRIVER', 'gd'),
+    'driver' => env('RAPIDEZ_IMAGE_DRIVER', extension_loaded('imagick') ? 'imagick' : 'gd'),
 
     'sizes' => [
         '80x80',   // Thumbs


### PR DESCRIPTION
imagick is not installed by default so it'll cause errors if it is not purposefully installed.
While gd is built in to php, so it will always be the safer option.

An alternative would be to configure the driver as follows 

```diff
-    'driver' => env('RAPIDEZ_IMAGE_DRIVER', 'gd'),
+    'driver' => env('RAPIDEZ_IMAGE_DRIVER', extension_loaded('imagick') ? 'imagick' : 'gd'),
```

But this may cause inconsistencies between systems