### PR TITLE
Laravel 11 support, upgrade spatie image to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.0|^8.1|^8.2",
-        "illuminate/http": "^9.0|^10.0",
-        "illuminate/routing": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0",
+        "illuminate/http": "^9.0|^10.0|^11.0",
+        "illuminate/routing": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0",
         "rapidez/core": "~0.54|^1.0|^2.0",
-        "spatie/image": "^2.2"
+        "spatie/image": "^3.3"
     },
     "autoload": {
         "psr-4": {

--- a/config/rapidez/imageresizer.php
+++ b/config/rapidez/imageresizer.php
@@ -21,13 +21,13 @@ return [
 
     'watermarks' => [
         'positions' => [
-            'stretch'      => Spatie\Image\Manipulations::FIT_STRETCH,
-            'tile'         => Spatie\Image\Manipulations::FIT_CROP,
-            'top-left'     => Spatie\Image\Manipulations::POSITION_TOP_LEFT,
-            'top-right'    => Spatie\Image\Manipulations::POSITION_TOP_RIGHT,
-            'bottom-left'  => Spatie\Image\Manipulations::POSITION_BOTTOM_LEFT,
-            'bottom-right' => Spatie\Image\Manipulations::POSITION_BOTTOM_RIGHT,
-            'center'       => Spatie\Image\Manipulations::POSITION_CENTER,
+            'stretch'      => \Spatie\Image\Enums\Fit::Stretch,
+            'tile'         => \Spatie\Image\Enums\Fit::Crop,
+            'top-left'     => \Spatie\Image\Enums\AlignPosition::TopLeft,
+            'top-right'    => \Spatie\Image\Enums\AlignPosition::TopRight,
+            'bottom-left'  => \Spatie\Image\Enums\AlignPosition::BottomLeft,
+            'bottom-right' => \Spatie\Image\Enums\AlignPosition::BottomRight,
+            'center'       => \Spatie\Image\Enums\AlignPosition::Center,
         ],
     ],
 


### PR DESCRIPTION
No functional changes have been made, only had to account for the breaking changes.

if `config/rapidez/imageresizer.php` has been published with the watermark positions it will need to be updated