### PR TITLE
Allow for slashes in SKU

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ $patterns = [
 
 if (config('rapidez.imageresizer.sku.enabled')) {
     Route::get('storage/{store}/resizes/{size}/sku/{file}', [ImageController::class, 'redirectFromSku'])
+        ->where('file', '(.*)')
         ->name('resized-sku');
 }
 


### PR DESCRIPTION
The standard pattern does not allow for a slash in the SKU. By manually setting it like this we're able to allow them without needing to urlencode anything.