### PR TITLE
Fix not found errors for placeholder

### DIFF
--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -158,7 +158,7 @@ class ImageController extends Controller
 
     private function getPlaceholderImageHash()
     {
-        return Cache::rememberForever('placeholder-hash-'.config('rapidez.store'), fn () => md5(file_get_contents(config('rapidez.imageresizer.external.magento').'/catalog/product'.Str::start(Rapidez::config('catalog/placeholder/image_placeholder'), '/'))));
+        return Cache::rememberForever('placeholder-hash-'.config('rapidez.store'), fn () => md5(@file_get_contents(Str::finish(config('rapidez.imageresizer.external.magento'), '/').'catalog/product'.Str::start(Rapidez::config('catalog/placeholder/image_placeholder'), '/'))));
     }
 
     public function storage()


### PR DESCRIPTION
In some setups the string concatenation caused `/media//catalog` paths, causing 404 errors instead of a placeholder image.
This 404 warning didn't get caught either. So we'd end up with a 500 error on the image url.